### PR TITLE
Update DebianUbuntuInstall.sh

### DIFF
--- a/installation/DebianUbuntuInstall.sh
+++ b/installation/DebianUbuntuInstall.sh
@@ -51,7 +51,7 @@ fi
 
 # Proceed with building and installing if all tests succeeded.
 mkdir BUILD; cd BUILD
-cmake -D BUILD_SLIMGUI=ON ../SLiM && make -j$(nproc) || { printf "Build failed. Please see the output and make a post on the slim-discuss mailing list.\n"; mv /tmp/BUILD/CMakeFiles/CMakeOutput.log ~/.SLiM_CMakeOutput.log; exit;}
+cmake -D BUILD_SLIMGUI=ON ../SLiM && make -j$(nproc) || { printf "Build failed. Please see the output and make a post on the slim-discuss mailing list.\nThe output from this build is stored here: SLiM-CMakeOutput-$(date -Is).log.\nYou may be asked to upload this file during a support request."; mv /tmp/BUILD/CMakeFiles/CMakeOutput.log /var/log/SLiM-CMakeOutput-$(date -Is).log; exit;}
 
 { mkdir -p /usr/bin /usr/share/icons/hicolor/scalable/apps/ /usr/share/icons/hicolor/scalable/mimetypes /usr/share/mime/packages /usr/share/applications /usr/share/metainfo/;} || { echo "Some directory necessary for installation was not successfully created. Please see the output and make a post on the slim-discuss mailing list."; exit;}
 


### PR DESCRIPTION
Corrects the target directory of the CMake log when builds fail; they are now stored in /var/log/ rather than the superuser's home directory.