### PR TITLE
Update UbuntuDebianInstaller.sh to properly download tarball with curl

### DIFF
--- a/installation/DebianUbuntuInstall.sh
+++ b/installation/DebianUbuntuInstall.sh
@@ -86,7 +86,7 @@ inspect this script, and your system, as other issues may exist." | fold -sw 80;
 }
 
 if [[ $curlinstalled == 0 ]]; then
-    { curl https://github.com/MesserLab/SLiM/archive/refs/tags/v4.2.2.tar.gz > \
+    { curl -L https://github.com/MesserLab/SLiM/archive/refs/tags/v4.2.2.tar.gz > \
            SLiM-4.2.2.tar.gz && tar -x -f SLiM-4.2.2.tar.gz && \
           mv SLiM-4.2.2 SLiM;
     } || {


### PR DESCRIPTION
The command to download the tarball using curl should have the "-L" flag, otherwise the downloaded file is empty and not really a tar file, resulting in installation error. My change here fixed that. This was tested on Ubuntu 22.04.6. u