### PR TITLE
Update autotetraploid.slim

### DIFF
--- a/models/autotetraploid.slim
+++ b/models/autotetraploid.slim
@@ -1,5 +1,6 @@
 //William W. Booker, 10 January 2024: autotetraploidy
 //Based on a concept by Yaniv Brandvain and Peter Ralph
+//If used, please cite the following paper (Booker and Schrider 2025): https://doi.org/10.1086/733334
 /*  
 	Tetraploidy:
 	


### PR DESCRIPTION
I am updating this only to add citation instructions so it is clear when authors use this script which version is being used. I have come across a couple papers now that reference the script but it is unclear if the authors are referencing this version or the previous which had errors, so hopefully this will help ameliorate this issue. 